### PR TITLE
TPA message fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.2
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
-mod_version=0.2.1
+mod_version=0.2.2
 maven_group=net.syrupstudios
 archives_base_name=syrup-essentials
 

--- a/src/main/java/net/syrupstudios/syrupessentials/util/TeleportManager.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/util/TeleportManager.java
@@ -57,7 +57,7 @@ public class TeleportManager {
                     request.getSenderPlayer().getUUID(),
                     request
             );
-            TELEPORT_APPROVAL_REQUESTS.remove(receiver.getUUID());
+            TELEPORT_APPROVAL_REQUESTS.remove(request.getSenderPlayer().getUUID());
             return 1;
         }
         receiver.sendSystemMessage(Component.literal("Teleport Request Has Expired"));
@@ -71,9 +71,10 @@ public class TeleportManager {
                         .filter(tr -> tr.getReceiverPlayerUUID().equals(receiver.getUUID()))
                         .findFirst();
         if(possibleTeleportRequest.isPresent()){
-            possibleTeleportRequest.get().getSenderPlayer().sendSystemMessage(Component.literal("Teleport Request Denied."));
+            TeleportRequest request = possibleTeleportRequest.get();
+            request.getSenderPlayer().sendSystemMessage(Component.literal("Teleport Request Denied."));
             receiver.sendSystemMessage(Component.literal("Teleport Request Denied."));
-            TELEPORT_APPROVAL_REQUESTS.remove(receiver.getUUID());
+            TELEPORT_APPROVAL_REQUESTS.remove(request.getSenderPlayer().getUUID());
             return 1;
         }
         receiver.sendSystemMessage(Component.literal("No currently pending teleports found."));


### PR DESCRIPTION
Fixed an issue where players were still receiving a "TPA Request Expired" after accepting or denying a teleport