### PR TITLE
TPA Tweaks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.2
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
-mod_version=0.2.2
+mod_version=0.2.3
 maven_group=net.syrupstudios
 archives_base_name=syrup-essentials
 

--- a/src/main/java/net/syrupstudios/syrupessentials/commands/TeleportCommands.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/commands/TeleportCommands.java
@@ -9,6 +9,7 @@ import com.mojang.logging.LogUtils;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.commands.arguments.UuidArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -31,14 +32,27 @@ public class TeleportCommands {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("tp") //todo: this doesn't overwrite existing tp
+                .requires(source -> source.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                .then(Commands.argument("player", EntityArgument.player())
+                        .executes(TeleportCommands::tp)));
+
         dispatcher.register(Commands.literal("tpa")
                 .then(Commands.argument("player", EntityArgument.player())
                         .executes(TeleportCommands::tpa)));
 
         dispatcher.register(Commands.literal("tpaccept")
+                .then(Commands.argument("UUID", UuidArgument.uuid())
+                        .executes(TeleportCommands::tpaAcceptPlayerUUID))
+                .then(Commands.argument("player", EntityArgument.player())
+                        .executes(TeleportCommands::tpaAcceptPlayer))
                 .executes(TeleportCommands::tpaAccept));
 
         dispatcher.register(Commands.literal("tpdeny")
+                .then(Commands.argument("UUID", UuidArgument.uuid())
+                        .executes(TeleportCommands::tpaDenyPlayerUUID))
+                .then(Commands.argument("player", EntityArgument.player())
+                        .executes(TeleportCommands::tpaDenyPlayer))
                 .executes(TeleportCommands::tpaDeny));
 
         dispatcher.register(Commands.literal("home")
@@ -82,6 +96,20 @@ public class TeleportCommands {
 
         dispatcher.register(Commands.literal("back")
                 .executes(TeleportCommands::back));
+    }
+
+    private static int tp(CommandContext<CommandSourceStack> context) {
+        try {
+            ServerPlayer target = EntityArgument.getPlayer(context, "player");
+            teleportPlayer(
+                    new TeleportPos(target.level(), target.position(), target.getXRot(), target.getYRot()),
+                    context.getSource().getPlayerOrException(),
+                    true
+            );
+            return 1;
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
     private static CompletableFuture<Suggestions> suggestHomes(
@@ -308,7 +336,6 @@ public class TeleportCommands {
             PlayerData player = DataManager.getOrCreatePlayer(serverPlayer).orElseThrow();
             Map<String, TeleportPos> homes = player.getHomes().getDestinations();
 
-
             if(homes.size() == 1){
                 teleportPlayer(homes.get(homes.keySet().iterator().next()), serverPlayer, true);
                 return 1;
@@ -351,8 +378,40 @@ public class TeleportCommands {
         return TeleportManager.denyTeleportRequest(context.getSource().getPlayer());
     }
 
+    private static int tpaDenyPlayer(CommandContext<CommandSourceStack> context) {
+        try{
+            return TeleportManager.denyTeleportRequestPlayer(
+                    context.getSource().getPlayer(),
+                    EntityArgument.getPlayer(context, "player"));
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
     private static int tpaAccept(CommandContext<CommandSourceStack> context) {
         return TeleportManager.approveTeleportRequest(context.getSource().getPlayer());
+    }
+
+    private static int tpaAcceptPlayer(CommandContext<CommandSourceStack> context) {
+        try{
+            return TeleportManager.approveTeleportRequestPlayer(
+                    context.getSource().getPlayer(),
+                    EntityArgument.getPlayer(context, "player"));
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private static int tpaAcceptPlayerUUID(CommandContext<CommandSourceStack> context) {
+        return TeleportManager.approveTeleportRequestPlayer(
+                context.getSource().getPlayer(),
+                context.getSource().getServer().getPlayerList().getPlayer(UuidArgument.getUuid(context, "UUID")));
+    }
+
+    private static int tpaDenyPlayerUUID(CommandContext<CommandSourceStack> context) {
+        return TeleportManager.denyTeleportRequestPlayer(
+                context.getSource().getPlayer(),
+                context.getSource().getServer().getPlayerList().getPlayer(UuidArgument.getUuid(context, "UUID")));
     }
 
     private static int tpa(CommandContext<CommandSourceStack> context) {

--- a/src/main/java/net/syrupstudios/syrupessentials/commands/TeleportCommands.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/commands/TeleportCommands.java
@@ -32,11 +32,6 @@ public class TeleportCommands {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-        dispatcher.register(Commands.literal("tp") //todo: this doesn't overwrite existing tp
-                .requires(source -> source.hasPermission(Commands.LEVEL_GAMEMASTERS))
-                .then(Commands.argument("player", EntityArgument.player())
-                        .executes(TeleportCommands::tp)));
-
         dispatcher.register(Commands.literal("tpa")
                 .then(Commands.argument("player", EntityArgument.player())
                         .executes(TeleportCommands::tpa)));
@@ -96,20 +91,6 @@ public class TeleportCommands {
 
         dispatcher.register(Commands.literal("back")
                 .executes(TeleportCommands::back));
-    }
-
-    private static int tp(CommandContext<CommandSourceStack> context) {
-        try {
-            ServerPlayer target = EntityArgument.getPlayer(context, "player");
-            teleportPlayer(
-                    new TeleportPos(target.level(), target.position(), target.getXRot(), target.getYRot()),
-                    context.getSource().getPlayerOrException(),
-                    true
-            );
-            return 1;
-        } catch (Exception e) {
-            return 0;
-        }
     }
 
     private static CompletableFuture<Suggestions> suggestHomes(

--- a/src/main/java/net/syrupstudios/syrupessentials/mixin/TeleportCommandMixin.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/mixin/TeleportCommandMixin.java
@@ -1,0 +1,49 @@
+package net.syrupstudios.syrupessentials.mixin;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.commands.TeleportCommand;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.RelativeMovement;
+import net.syrupstudios.syrupessentials.data.PlayerData;
+import net.syrupstudios.syrupessentials.util.DataManager;
+import net.syrupstudios.syrupessentials.util.TeleportPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Set;
+
+@Mixin(TeleportCommand.class)
+public class TeleportCommandMixin {
+
+    @Inject(
+            method = "performTeleport",
+            at = @At("HEAD")
+    )
+    private static void beforeTeleport(
+            CommandSourceStack source,
+            Entity target,
+            ServerLevel level,
+            double x,
+            double y,
+            double z,
+            Set<RelativeMovement> relativeMovements,
+            float yRot,
+            float xRot,
+            @Coerce Object lookAt,
+            CallbackInfo ci
+    ) {
+        if (!(target instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+
+        DataManager.getOrCreatePlayer(serverPlayer)
+                .orElseThrow()
+                .addTeleportHistory(
+                        new TeleportPos(target.level(), target.position(), target.getXRot(), target.getYRot()));
+    }
+}

--- a/src/main/java/net/syrupstudios/syrupessentials/util/TeleportManager.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/util/TeleportManager.java
@@ -1,5 +1,6 @@
 package net.syrupstudios.syrupessentials.util;
 
+import com.mojang.logging.LogUtils;
 import lombok.NoArgsConstructor;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.ClickEvent;
@@ -8,6 +9,7 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.syrupstudios.syrupessentials.data.PlayerData;
+import org.slf4j.Logger;
 
 import java.util.HashMap;
 import java.util.Objects;
@@ -20,6 +22,7 @@ public class TeleportManager {
     private static final HashMap<UUID, TeleportRequest> TELEPORT_APPROVAL_REQUESTS = new HashMap<>();
     private static final int TIMEOUT_THRESHOLD = 600; //TODO: replace w/ config timeout
     private static long currentTick;
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static int teleportRequest(ServerPlayer serverPlayer, MinecraftServer server, String destinationPlayerName){
         ServerPlayer target = server.getPlayerList().getPlayerByName(destinationPlayerName);
@@ -32,28 +35,29 @@ public class TeleportManager {
             TELEPORT_APPROVAL_REQUESTS.put(
                     serverPlayer.getUUID(),
                     new TeleportRequest(
-                            new TeleportPos(target.level(), target.position(), target.getXRot(), target.getYRot()),
                             target.getUUID(),
                             serverPlayer,
                             currentTick + TIMEOUT_THRESHOLD
                     ));
-//            target.sendSystemMessage(Component.literal("Receiving teleport request from: "+serverPlayer.getDisplayName().getString()));
-//            target.sendSystemMessage(Component.literal("Type /tpaccept or /tpdeny to respond"));
+
             target.sendSystemMessage(
-                    Component.literal("Teleport request: ")
+                    Component.literal("Teleport request: ").withStyle(style -> style
+                                    .withColor(ChatFormatting.WHITE))
                             .append(Component.literal("[ "))
                             .append(Component.literal(serverPlayer.getDisplayName().getString())
                                     .withStyle(style -> style
                                             .withColor(ChatFormatting.AQUA))
-                            .append(Component.literal(" ➤ "))
-                            .append(Component.literal(destinationPlayerName))
-                                    .withStyle(style -> style
-                                            .withColor(ChatFormatting.AQUA))
-                            .append(Component.literal(" ]"))
-
-                            .append(Component.literal("\n Select an option: "))
+                            .append(Component.literal(" ➤ ")
                                     .withStyle(style -> style
                                             .withColor(ChatFormatting.WHITE))
+                            .append(Component.literal(destinationPlayerName)
+                                    .withStyle(style -> style
+                                        .withColor(ChatFormatting.AQUA)))
+                            .append(Component.literal(" ]")))
+
+                            .append(Component.literal("\n Select an option: ")
+                                    .withStyle(style -> style
+                                            .withColor(ChatFormatting.WHITE)))
                             .append(Component.literal("Accept ✔")
                                     .withStyle(style -> style
                                             .withColor(ChatFormatting.GREEN)
@@ -67,14 +71,16 @@ public class TeleportManager {
                                                     Component.literal("Accept teleport request")
                                             ))
                                     ))
-                            .append(Component.literal(" | "))
+                            .append(Component.literal(" | ")
+                                    .withStyle(style -> style
+                                    .withColor(ChatFormatting.WHITE)))
                             .append(Component.literal("Deny ✘")
                                     .withStyle(style -> style
                                             .withColor(ChatFormatting.RED)
                                             .withBold(true)
                                             .withClickEvent(new ClickEvent(
                                                     ClickEvent.Action.RUN_COMMAND,
-                                                    "/tpdeny" + serverPlayer.getUUID()
+                                                    "/tpdeny " + serverPlayer.getUUID()
                                             ))
                                             .withHoverEvent(new HoverEvent(
                                                     HoverEvent.Action.SHOW_TEXT,
@@ -184,8 +190,28 @@ public class TeleportManager {
                 }
         );
 
-        APPROVED_TELEPORTS.entrySet().removeIf(entry ->
-                teleportPlayer(entry.getValue().getTeleportPos(), entry.getValue().getSenderPlayer(), true));
+        APPROVED_TELEPORTS.entrySet().removeIf(entry -> {
+            try {
+                ServerPlayer target = Objects.requireNonNull(
+                        entry.getValue()
+                                .getSenderPlayer()
+                                .getServer())
+                        .getPlayerList()
+                        .getPlayer(entry.getValue().getReceiverPlayerUUID());
+                assert target != null;
+                teleportPlayer(
+                        new TeleportPos(target.level(), target.position(), target.getXRot(), target.getYRot()),
+                        entry.getValue().getSenderPlayer(),
+                        true
+                );
+
+            } catch (Exception e) {
+                LOGGER.error("Error while removing teleport from Approved Teleports for {}", entry);
+                return false;
+            }
+            return true;
+        });
+
     }
 
     public void flush(){

--- a/src/main/java/net/syrupstudios/syrupessentials/util/TeleportManager.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/util/TeleportManager.java
@@ -1,7 +1,10 @@
 package net.syrupstudios.syrupessentials.util;
 
 import lombok.NoArgsConstructor;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.syrupstudios.syrupessentials.data.PlayerData;
@@ -34,8 +37,51 @@ public class TeleportManager {
                             serverPlayer,
                             currentTick + TIMEOUT_THRESHOLD
                     ));
-            target.sendSystemMessage(Component.literal("Receiving teleport request from: "+serverPlayer.getDisplayName().getString()));
-            target.sendSystemMessage(Component.literal("Type /tpaccept or /tpdeny to respond"));
+//            target.sendSystemMessage(Component.literal("Receiving teleport request from: "+serverPlayer.getDisplayName().getString()));
+//            target.sendSystemMessage(Component.literal("Type /tpaccept or /tpdeny to respond"));
+            target.sendSystemMessage(
+                    Component.literal("Teleport request: ")
+                            .append(Component.literal("[ "))
+                            .append(Component.literal(serverPlayer.getDisplayName().getString())
+                                    .withStyle(style -> style
+                                            .withColor(ChatFormatting.AQUA))
+                            .append(Component.literal(" ➤ "))
+                            .append(Component.literal(destinationPlayerName))
+                                    .withStyle(style -> style
+                                            .withColor(ChatFormatting.AQUA))
+                            .append(Component.literal(" ]"))
+
+                            .append(Component.literal("\n Select an option: "))
+                                    .withStyle(style -> style
+                                            .withColor(ChatFormatting.WHITE))
+                            .append(Component.literal("Accept ✔")
+                                    .withStyle(style -> style
+                                            .withColor(ChatFormatting.GREEN)
+                                            .withBold(true)
+                                            .withClickEvent(new ClickEvent(
+                                                    ClickEvent.Action.RUN_COMMAND,
+                                                    "/tpaccept " + serverPlayer.getUUID()
+                                            ))
+                                            .withHoverEvent(new HoverEvent(
+                                                    HoverEvent.Action.SHOW_TEXT,
+                                                    Component.literal("Accept teleport request")
+                                            ))
+                                    ))
+                            .append(Component.literal(" | "))
+                            .append(Component.literal("Deny ✘")
+                                    .withStyle(style -> style
+                                            .withColor(ChatFormatting.RED)
+                                            .withBold(true)
+                                            .withClickEvent(new ClickEvent(
+                                                    ClickEvent.Action.RUN_COMMAND,
+                                                    "/tpdeny" + serverPlayer.getUUID()
+                                            ))
+                                            .withHoverEvent(new HoverEvent(
+                                                    HoverEvent.Action.SHOW_TEXT,
+                                                    Component.literal("Deny teleport request")
+                                            ))
+                                    ))
+            ));
             return 1;
         }
         return -1;
@@ -47,6 +93,19 @@ public class TeleportManager {
                         .stream()
                         .filter(tr -> tr.getReceiverPlayerUUID().equals(receiver.getUUID()))
                         .findFirst();
+        return processTeleportRequestApproval(receiver, possibleTeleportRequest);
+    }
+
+    public static int approveTeleportRequestPlayer(ServerPlayer receiver, ServerPlayer target) {
+        Optional<TeleportRequest> possibleTeleportRequest =
+                TELEPORT_APPROVAL_REQUESTS.values()
+                        .stream()
+                        .filter(tr -> tr.getReceiverPlayerUUID().equals(receiver.getUUID()) && tr.getSenderPlayer().getUUID().equals(target.getUUID()))
+                        .findFirst();
+        return processTeleportRequestApproval(receiver, possibleTeleportRequest);
+    }
+
+    private static int processTeleportRequestApproval(ServerPlayer receiver, Optional<TeleportRequest> possibleTeleportRequest) {
         if(possibleTeleportRequest.isPresent()){
             possibleTeleportRequest.get().getSenderPlayer().sendSystemMessage(Component.literal("Teleport Request Approved, Teleporting.."));
             receiver.sendSystemMessage(
@@ -70,6 +129,19 @@ public class TeleportManager {
                         .stream()
                         .filter(tr -> tr.getReceiverPlayerUUID().equals(receiver.getUUID()))
                         .findFirst();
+        return processTeleportRequestDenial(receiver, possibleTeleportRequest);
+    }
+
+    public static int denyTeleportRequestPlayer(ServerPlayer receiver, ServerPlayer target){
+        Optional<TeleportRequest> possibleTeleportRequest =
+                TELEPORT_APPROVAL_REQUESTS.values()
+                        .stream()
+                        .filter(tr -> tr.getReceiverPlayerUUID().equals(receiver.getUUID()))
+                        .findFirst();
+        return processTeleportRequestDenial(receiver, possibleTeleportRequest);
+    }
+
+    private static int processTeleportRequestDenial(ServerPlayer receiver, Optional<TeleportRequest> possibleTeleportRequest) {
         if(possibleTeleportRequest.isPresent()){
             TeleportRequest request = possibleTeleportRequest.get();
             request.getSenderPlayer().sendSystemMessage(Component.literal("Teleport Request Denied."));

--- a/src/main/java/net/syrupstudios/syrupessentials/util/TeleportRequest.java
+++ b/src/main/java/net/syrupstudios/syrupessentials/util/TeleportRequest.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 @Data
 @AllArgsConstructor
 public class TeleportRequest {
-    private TeleportPos teleportPos;
     private UUID receiverPlayerUUID;
     private ServerPlayer senderPlayer;
     private long expiresAtTick;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,9 @@
 			"net.syrupstudios.syrupessentials.SyrupEssentials"
 		]
 	},
-	"mixins": [],
+	"mixins": [
+		"syrup-essentials.mixins.json"
+	],
 	"depends": {
 		"fabricloader": ">=0.18.4",
 		"minecraft": "~1.20.1",

--- a/src/main/resources/syrup-essentials.mixins.json
+++ b/src/main/resources/syrup-essentials.mixins.json
@@ -1,8 +1,10 @@
 {
-	"required": false,
-	"package": "net.syrupstudios.syrupessentials",
+	"required": true,
+	"package": "net.syrupstudios.syrupessentials.mixin",
 	"compatibilityLevel": "JAVA_17",
-	"mixins": [],
+	"mixins": [
+		"TeleportCommandMixin"
+	],
 	"injectors": {
 		"defaultRequire": 1
 	},


### PR DESCRIPTION
Slight overhaul of TPA:

- Support for player specification for tpaccept (for multiple tpa's)
- colored and stylized notification in chat for tpa requests
- support for clicking Approve or Deny for requests
- requests now specify who is teleporting to who (this will be handy for when /tpahere is implemented)
- position is now calculated at time of accept, not at the time of request
- Mixin added for /tp, so OPs can now /back after using minecraft's /tp command